### PR TITLE
Add real plist value type

### DIFF
--- a/lib/puppet/provider/property_list_key/rubycocoa.rb
+++ b/lib/puppet/provider/property_list_key/rubycocoa.rb
@@ -36,6 +36,8 @@ Puppet::Type.type(:property_list_key).provide(:rubycocoa) do
     case resource[:value_type]
     when :integer
       plist_value = Integer(resource[:value].first)
+    when :real
+      plist_value = Float(resource[:value].first)
     when :boolean
       if resource[:value].to_s =~ /false/i
         plist_value = false
@@ -82,6 +84,8 @@ Puppet::Type.type(:property_list_key).provide(:rubycocoa) do
     case resource[:value_type]
     when :integer
       plist[resource[:key]] = Integer(item_value.first)
+    when :real
+      plist[resource[:key]] = Float(item_value.first)
     when :array, :hash
       plist[resource[:key]] = item_value
     when :boolean

--- a/lib/puppet/type/property_list_key.rb
+++ b/lib/puppet/type/property_list_key.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:property_list_key) do
   newparam(:value_type) do
     desc "The value type for the plist key's value"
 
-    newvalues('string', 'boolean', 'array', 'hash', 'integer')
+    newvalues('string', 'boolean', 'array', 'hash', 'integer', 'real')
     defaultto 'string'
   end
 

--- a/spec/unit/puppet/provider/property_list_key/rubycocoa_spec.rb
+++ b/spec/unit/puppet/provider/property_list_key/rubycocoa_spec.rb
@@ -128,6 +128,35 @@ describe 'The rubycocoa provider for the property_list_key type' do
     provider.value.should == 8
   end
 
+  it 'should write a real value if an integer value_type is passed' do
+    resource[:value] = '4'
+    resource[:value_type] = :real
+    provider.create
+    provider.value.class.should == Float
+  end
+
+  it 'should write a real value if a float value_type is passed' do
+    resource[:value] = '4.0'
+    resource[:value_type] = :real
+    provider.create
+    provider.value.class.should == Float
+  end
+
+  it 'should set a real value' do
+    resource[:value] = '4'
+    resource[:value_type] = :real
+    provider.create
+    provider.value.should == 4.0
+  end
+
+  it 'should set a float value with value=' do
+    resource[:value] = '4.0'
+    resource[:value_type] = :real
+    provider.create
+    provider.value = '8.0'
+    provider.value.should == 8.0
+  end
+
   it 'should write an array value if an array value_type is passed' do
     resource[:value] = ['array', 'of', 'values']
     resource[:value_type] = :array

--- a/spec/unit/puppet/type/property_list_key_spec.rb
+++ b/spec/unit/puppet/type/property_list_key_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Type.type(:property_list_key) do
 
   it 'raises an error if an invalid ensure value is passed' do
     expect { resource[:ensure] = 'file' }.to raise_error \
-      Puppet::Error, /Parameter ensure failed: Invalid value "file"/
+      Puppet::Error, /Invalid value "file"/
   end
 
   it 'accepts a valid path value' do
@@ -30,10 +30,10 @@ describe Puppet::Type.type(:property_list_key) do
 
   it 'raises an error if an absolute path is not passed' do
     expect { resource[:path] = 'foo' }.to raise_error Puppet::Error,
-      /Parameter path failed: Path must be absolute:/
+      /Path must be absolute:/
   end
 
-  %w{ string boolean integer hash array }.each do |value|
+  %w{ string boolean integer real hash array }.each do |value|
     it "accepts #{value} as a valid value_type" do
         resource[:value_type] = value
         resource[:value_type].should == value.intern
@@ -42,6 +42,6 @@ describe Puppet::Type.type(:property_list_key) do
 
   it 'raises an error if an invalid value_type is passed' do
     expect { resource[:value_type] = 'blargh' }.to raise_error \
-      Puppet::Error, /Parameter value_type failed: Invalid value "blargh"/
+      Puppet::Error, /Invalid value "blargh"/
   end
 end


### PR DESCRIPTION
Some plist values are of the type 'real' but this was not previously
allowed.

Small spec changes due to varying puppet version differences.
