### PR TITLE
Fix array wrapping around hash types.

### DIFF
--- a/lib/puppet/provider/property_list_key/rubycocoa.rb
+++ b/lib/puppet/provider/property_list_key/rubycocoa.rb
@@ -86,7 +86,7 @@ Puppet::Type.type(:property_list_key).provide(:rubycocoa) do
       plist[resource[:key]] = Integer(item_value.first)
     when :real
       plist[resource[:key]] = Float(item_value.first)
-    when :array, :hash
+    when :array
       plist[resource[:key]] = item_value
     when :boolean
       if item_value.to_s =~ /false/i


### PR DESCRIPTION
When a hash is passed into Puppet, it is actually a singleton array with a hash. Therefore, it needs to be "unwrapped" by grabbing the first element.

Addresses issue #7

~ Jonathan
