### PR TITLE
Require statement for CFPropertyList fails on case-sensistive filesystems

### DIFF
--- a/lib/puppet/feature/cfpropertylist.rb
+++ b/lib/puppet/feature/cfpropertylist.rb
@@ -2,7 +2,7 @@ require 'puppet/util/feature'
 #Puppet.features.add(:cfpropertylist, :libs => ['CFPropertyList'])
 Puppet.features.add(:cfpropertylist) do
   begin
-    require 'CFPropertyList'
+    require 'cfpropertylist'
   rescue ArgumentError
     raise Puppet::Error, "The version of CFPropertyList on the system is too old. " +
       "Please ensure that you have version '2.2.5' of the CFPropertyList gem " +


### PR DESCRIPTION
When using this on case-sensitive filesystems, I get this error:

`Failed to load feature test for cfpropertylist: cannot load such file -- CFPropertyList`

Runs ok when changing the require to: `require 'cfpropertylist'`
