### PR TITLE
Make cfpropertylist the default

### DIFF
--- a/lib/puppet/provider/property_list_key/cfpropertylist.rb
+++ b/lib/puppet/provider/property_list_key/cfpropertylist.rb
@@ -1,8 +1,8 @@
 Puppet::Type.type(:property_list_key).provide(:cfpropertylist) do
   desc "An OS X provider for creating property list keys and values"
 
-  confine    :feature => :cfpropertylist
-  defaultfor :feature => :cfpropertylist
+  confine    :feature  => :cfpropertylist
+  defaultfor :osfamily => :darwin
 
   def exists?
     return false unless File.file? resource[:path]

--- a/lib/puppet/provider/property_list_key/rubycocoa.rb
+++ b/lib/puppet/provider/property_list_key/rubycocoa.rb
@@ -3,7 +3,6 @@ include OSX if Puppet.features.rubycocoa?
 Puppet::Type.type(:property_list_key).provide(:rubycocoa) do
   desc "An OS X provider for creating property list keys and values"
 
-  defaultfor :feature => :rubycocoa
   confine    :feature => :rubycocoa
 
   def exists?


### PR DESCRIPTION
Previously, I had made rubycocoa the default provider for the rubycocoa 
feature, and the same for cfpropertylist. The problem would arise where you
could have BOTH libraries installed, and both would be listed as the default
provider. Since Rubycocoa is effectively dead, I'm making cfpropertylist the
default from here-on-out.
