### PR TITLE
Add CFData support (for storing binary data in base64 encoding in 'data' key type)

### DIFF
--- a/lib/puppet/provider/property_list_key/cfpropertylist.rb
+++ b/lib/puppet/provider/property_list_key/cfpropertylist.rb
@@ -32,6 +32,8 @@ Puppet::Type.type(:property_list_key).provide(:cfpropertylist) do
       plist_value = Integer(resource[:value].first)
     when :real
       plist_value = Float(resource[:value].first)
+    when :data
+      plist_value = CFPropertyList::Blob.new(resource[:value].first)
     when :boolean
       if resource[:value].to_s =~ /false/i
         plist_value = false
@@ -80,6 +82,8 @@ Puppet::Type.type(:property_list_key).provide(:cfpropertylist) do
       plist[resource[:key]] = Integer(item_value.first)
     when :real
       plist[resource[:key]] = Float(item_value.first)
+    when :data
+      plist[resource[:key]] = CFPropertyList::Blob.new(item_value.first)
     when :array
       plist[resource[:key]] = item_value
     when :boolean

--- a/lib/puppet/type/property_list_key.rb
+++ b/lib/puppet/type/property_list_key.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:property_list_key) do
   newparam(:value_type) do
     desc "The value type for the plist key's value"
 
-    newvalues('string', 'boolean', 'array', 'hash', 'integer', 'real')
+    newvalues('string', 'boolean', 'array', 'hash', 'integer', 'real', 'data')
     defaultto 'string'
   end
 


### PR DESCRIPTION
This allows the user to set value_type to 'data', and we'll mark the incoming value as a Blob, which will cause the underlying CFPropertyList class to treat it as binary data and store it in a 'data' type